### PR TITLE
Resource groups not unique and docs enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Variable | Type | Description | Default
 `ibmcloud_api_key` | String | The IBM Cloud platform API key needed to deploy IAM enabled resources |
 `generation` | String | Generation of VPC. Can be 1 or 2 | `2`
 `ibm_region` | String | IBM Cloud region where all resources will be deployed |
-`resource_group` | String | Name for IBM Cloud Resource Group where resources will be deployed | 
+`cluster_resource_group` | String | Name for IBM Cloud Resource Group where the cluster was deployed |
+`logging_resource_group` | String | Name for IBM Cloud Resource Group where logging resources was or will be deployed |
+`monitoring_resource_group` | String | Name for IBM Cloud Resource Group where monitoring resources was or will be deployed |
 `cluster_name` | String | Name of the cluster where resources will be deployed | 
 `bring_your_own_logging` | String | True or false. A logging instance will be created if `false` | `false`
 `logging_instance_name` | String | Name of logging instance. Name of the instance to be created if not bringing your own instance, otherwise use the name of your existing instance | `cluster-logging`

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Variable | Type | Description | Default
 `cluster_resource_group` | String | Name for IBM Cloud Resource Group where the cluster was deployed |
 `logging_resource_group` | String | Name for IBM Cloud Resource Group where logging resources was or will be deployed |
 `monitoring_resource_group` | String | Name for IBM Cloud Resource Group where monitoring resources was or will be deployed |
+`provision_activity_tracker` | String | Provision activity tracker. Only one instance of Activity Tracker can be created in a region. Can be `true` or `false` |
 `cluster_name` | String | Name of the cluster where resources will be deployed | 
 `bring_your_own_logging` | String | True or false. A logging instance will be created if `false` | `false`
 `logging_instance_name` | String | Name of logging instance. Name of the instance to be created if not bringing your own instance, otherwise use the name of your existing instance | `cluster-logging`

--- a/main.tf
+++ b/main.tf
@@ -16,8 +16,16 @@ provider ibm {
 # Resource Group
 ##############################################################################
 
-data ibm_resource_group group {
-  name = var.resource_group
+data ibm_resource_group cluster_resource_group {
+  name = var.cluster_resource_group
+}
+
+data ibm_resource_group logging_resource_group {
+  name = var.logging_resource_group
+}
+
+data ibm_resource_group monitoring_resource_group {
+  name = var.monitoring_resource_group
 }
 
 ##############################################################################
@@ -29,7 +37,7 @@ data ibm_resource_group group {
 
 data ibm_container_cluster_config cluster {
   cluster_name_id   = var.cluster_name
-  resource_group_id = data.ibm_resource_group.group.id
+  resource_group_id = data.ibm_resource_group.cluster_resource_group.id
   admin             = true
 }
 
@@ -62,7 +70,7 @@ resource ibm_resource_instance activity_tracker {
   service           = "logdnaat"
   plan              = var.logging_plan
   location          = var.ibm_region
-  resource_group_id = data.ibm_resource_group.group.id
+  resource_group_id = data.ibm_resource_group.logging_resource_group.id
 
   parameters = {
     service-endpoints = var.logging_endpoint
@@ -79,7 +87,7 @@ resource ibm_resource_instance activity_tracker {
 
 module logging {
     source             = "./logging"
-    resource_group_id  = data.ibm_resource_group.group.id
+    resource_group_id  = data.ibm_resource_group.logging_resource_group.id
     use_data           = var.bring_your_own_logging
     ibm_region         = var.ibm_region
     name               = var.logging_instance_name
@@ -99,7 +107,7 @@ module logging {
 
 module monitor {
     source             = "./monitoring"
-    resource_group_id  = data.ibm_resource_group.group.id
+    resource_group_id  = data.ibm_resource_group.monitoring_resource_group.id
     use_data           = var.bring_your_own_monitor
     ibm_region         = var.ibm_region
     name               = var.monitor_name

--- a/variables.tf
+++ b/variables.tf
@@ -17,8 +17,18 @@ variable generation {
     default     = 2
 }
 
-variable resource_group {
-    description = "Name for IBM Cloud Resource Group where resources will be deployed"
+variable cluster_resource_group {
+    description = "Name for IBM Cloud Resource Group where the cluster was deployed"
+    type        = string
+}
+
+variable logging_resource_group {
+    description = "Name for IBM Cloud Resource Group where logging resources was or will be deployed"
+    type        = string
+}
+
+variable monitoring_resource_group {
+    description = "Name for IBM Cloud Resource Group where monitoring resources was or will be deployed"
     type        = string
 }
 


### PR DESCRIPTION
First I would like to thank you for this module.

However, I needed to use this in a use case where the logging a monitoring instances were in a different resource group than cluster, so I needed to make these changes and I am going up this PR.

In addition, I added in the README docs for `provision_activity_tracker` module variable.