### PR TITLE
Remove providers setup from module and enhacement docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This module will automatically deploy Logging and Mornitoring agents onto your Kubernetes on VPC Cluster. You can either bring your own logging and monitoring instances or provision them with this architecture. This can be run on [IBM Schematics](https://cloud.ibm.com/schematics) or in your local environment.
 
-![Logging Monitoring](../.docs/logging-monitoring-basic.png)
-
 ---
 
 ### Table of Contents

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Variable | Type | Description | Default
 `monitor_plan` | String | Only required when creating resource. Plan for logging instance. | `graduated-tier`
 `tags` | String | (Optional) List of tags for resource creation | `[]`
 `service_end_points` | String | Sets the endpoints for the resources if not bringing your own. Can be `public` or `private` | `private`
+`provision_activity_tracker` | String | Provision activity tracker. Only one instance of Activity Tracker can be created in a region. Can be `true` or `false` | `false`
 ---
 ## Outputs
 

--- a/logging/agent_setup.tf
+++ b/logging/agent_setup.tf
@@ -37,6 +37,7 @@ resource ibm_resource_key logdna_secret {
 resource kubernetes_secret logdna_agent_key {
   metadata {
     name      = "logdna-agent-key"
+    namespace = var.k8s_agent_namespace
   }
   data = {
     logdna-agent-key = ibm_resource_key.logdna_secret.credentials["ingestion_key"]
@@ -55,6 +56,7 @@ resource kubernetes_secret logdna_agent_key {
 resource kubernetes_daemonset logdna_agent {
   metadata {
     name = "logdna-agent"
+    namespace = var.k8s_agent_namespace
   }
   spec {
     selector {

--- a/logging/namespace.tf
+++ b/logging/namespace.tf
@@ -15,8 +15,7 @@ locals {
 # Create Namespace
 ##############################################################################
 
-resource kubernetes_namespace k8s_agent_namespace {
-  count = var.create_k8s_namespace ? 1: 0
+resource kubernetes_namespace ibm_observe {
   metadata {
     name = var.k8s_agent_namespace
   }
@@ -30,7 +29,7 @@ resource kubernetes_namespace k8s_agent_namespace {
 ##############################################################################
 
 data kubernetes_secret image_pull_secret {
-  count = var.create_k8s_namespace ? length(local.image_pull_secrets) : 0
+  count = length(local.image_pull_secrets)
   metadata {
     name = element(local.image_pull_secrets, count.index)
   }
@@ -44,10 +43,10 @@ data kubernetes_secret image_pull_secret {
 ##############################################################################
 
 resource kubernetes_secret copy_image_pull_secret {
-  count = var.create_k8s_namespace ? length(local.image_pull_secrets) : 0
+  count = length(local.image_pull_secrets)
   metadata {
     name      = "ibm-observe-${element(local.image_pull_secrets, count.index)}"
-    namespace = kubernetes_namespace.k8s_agent_namespace.0.metadata.0.name
+    namespace = kubernetes_namespace.ibm_observe.metadata.0.name
   }
   data      = {
     ".dockerconfigjson" = data.kubernetes_secret.image_pull_secret[count.index].data[".dockerconfigjson"]

--- a/logging/variables.tf
+++ b/logging/variables.tf
@@ -14,6 +14,11 @@ variable resource_group_id {
     description =  "ID of resource groupr for logdna instance"
 }
 
+variable k8s_agent_namespace {
+  description = "Namespace on the cluster where sysdig agents will be installed"
+  default = "ibm-observe"
+}
+
 variable use_data {
     description = "Use data block for logdna instance"
     default     = true

--- a/logging/versions.tf
+++ b/logging/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+      version = "~> 1.16.0"
+    }
+  
+  
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = "~> 1.13.3"
+    }
+  }
+
+}

--- a/main.tf
+++ b/main.tf
@@ -57,17 +57,18 @@ module logging {
 ##############################################################################
 
 module monitor {
-    source             = "./monitoring"
-    resource_group_id  = data.ibm_resource_group.group.id
-    use_data           = var.bring_your_own_monitor
-    ibm_region         = var.ibm_region
-    name               = var.monitor_name
-    cluster_name       = var.cluster_name
-    sysdig_image       = var.monitor_agent_image
-    sysdig_endpoint    = var.monitor_endpoint
-    monitor_plan       = var.monitor_plan
-    tags               = var.tags
-    end_points         = var.service_end_points
+    source               = "./monitoring"
+    create_k8s_namespace = var.k8s_logging_agent_namespace != var.k8s_monitoring_agent_namespace
+    resource_group_id    = data.ibm_resource_group.group.id
+    use_data             = var.bring_your_own_monitor
+    ibm_region           = var.ibm_region
+    name                 = var.monitor_name
+    cluster_name         = var.cluster_name
+    sysdig_image         = var.monitor_agent_image
+    sysdig_endpoint      = var.monitor_endpoint
+    monitor_plan         = var.monitor_plan
+    tags                 = var.tags
+    end_points           = var.service_end_points
 }
 
 ##############################################################################

--- a/main.tf
+++ b/main.tf
@@ -1,18 +1,4 @@
 ##############################################################################
-# Provider
-##############################################################################
-
-provider ibm {
-  ibmcloud_api_key = var.ibmcloud_api_key
-  region           = var.ibm_region
-  ibmcloud_timeout = 60
-  generation       = var.generation
-}
-
-##############################################################################
-
-
-##############################################################################
 # Resource Group
 ##############################################################################
 
@@ -22,33 +8,6 @@ data ibm_resource_group group {
 
 ##############################################################################
 
-
-##############################################################################
-# Cluster Data
-##############################################################################
-
-data ibm_container_cluster_config cluster {
-  cluster_name_id   = var.cluster_name
-  resource_group_id = data.ibm_resource_group.group.id
-  admin             = true
-}
-
-##############################################################################
-
-
-##############################################################################
-# Kubernetes Provider
-##############################################################################
-
-provider kubernetes {
-  load_config_file       = false
-  host                   = data.ibm_container_cluster_config.cluster.host
-  client_certificate     = data.ibm_container_cluster_config.cluster.admin_certificate
-  client_key             = data.ibm_container_cluster_config.cluster.admin_key
-  cluster_ca_certificate = data.ibm_container_cluster_config.cluster.ca_certificate
-}
-
-##############################################################################
 
 ##############################################################################
 # Activity Tracker

--- a/monitoring/agent_setup.tf
+++ b/monitoring/agent_setup.tf
@@ -114,7 +114,7 @@ resource kubernetes_cluster_role_binding sysdig_agent {
     name      = "sysdig-agent"
   }
 
-  depends_on = ["kubernetes_cluster_role.sysdig_agent"]
+  depends_on = [kubernetes_cluster_role.sysdig_agent]
 }
 
 ##############################################################################

--- a/monitoring/agent_setup.tf
+++ b/monitoring/agent_setup.tf
@@ -37,7 +37,7 @@ resource ibm_resource_key sysdig_secret {
 resource kubernetes_service_account sysdig_agent {
   metadata {
     name      = "sysdig-agent"
-    namespace = "ibm-observe"
+    namespace = var.k8s_agent_namespace
   }
   depends_on = [kubernetes_secret.copy_image_pull_secret, ibm_resource_key.sysdig_secret]
 }
@@ -106,7 +106,7 @@ resource kubernetes_cluster_role_binding sysdig_agent {
   subject {
     kind      = "ServiceAccount"
     name      = "sysdig-agent"
-    namespace = "ibm-observe"
+    namespace = var.k8s_agent_namespace
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"
@@ -127,7 +127,7 @@ resource kubernetes_cluster_role_binding sysdig_agent {
 resource kubernetes_secret sysdig_agent {
   metadata {
     name      = "sysdig-agent"
-    namespace = "ibm-observe"
+    namespace = var.k8s_agent_namespace
   }
   data = {
     access-key = ibm_resource_key.sysdig_secret.credentials["Sysdig Access Key"]
@@ -147,7 +147,7 @@ resource kubernetes_secret sysdig_agent {
 resource kubernetes_config_map sysdig_config_map {
   metadata {
     name      = "sysdig-agent"
-    namespace = "ibm-observe"
+    namespace = var.k8s_agent_namespace
     labels = {
       app = kubernetes_secret.sysdig_agent.metadata.0.name
     }
@@ -178,7 +178,7 @@ resource kubernetes_config_map sysdig_config_map {
 resource kubernetes_daemonset sysdig_agent {
   metadata {
     name      = "sysdig-agent"
-    namespace = "ibm-observe"
+    namespace = var.k8s_agent_namespace
     labels = {
       app = "sysdig-agent"
     }
@@ -196,6 +196,7 @@ resource kubernetes_daemonset sysdig_agent {
         }
       }
       spec {
+        service_account_name = kubernetes_service_account.sysdig_agent.metadata.0.name
         image_pull_secrets {
           name = "ibm-observe-icr-io"
         }

--- a/monitoring/namespace.tf
+++ b/monitoring/namespace.tf
@@ -31,7 +31,7 @@ resource kubernetes_namespace ibm_observe {
 data kubernetes_secret image_pull_secret {
   count = length(local.image_pull_secrets)
   metadata {
-    name = "default-${element(local.image_pull_secrets, count.index)}"
+    name = element(local.image_pull_secrets, count.index)
   }
 }
 

--- a/monitoring/variables.tf
+++ b/monitoring/variables.tf
@@ -28,6 +28,15 @@ variable cluster_name {
   description = "Name of cluster where sysdig agents will be installed"
 }
 
+variable create_k8s_namespace {
+  description = "Create namespace on the cluster where sysdig agents will be installed"
+}
+
+variable k8s_agent_namespace {
+  description = "Namespace on the cluster where sysdig agents will be installed"
+  default = "ibm-observe"
+}
+
 variable sysdig_endpoint {
   description = "API endpoint prefix for Sysdig (private, public, direct)"
   default     = "private" 

--- a/monitoring/versions.tf
+++ b/monitoring/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+      version = "~> 1.16.0"
+    }
+  
+  
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = "~> 1.13.3"
+    }
+  }
+
+}

--- a/resource_data/versions.tf
+++ b/resource_data/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+      version = "~> 1.16.0"
+    }  
+  }
+
+}

--- a/variables.tf
+++ b/variables.tf
@@ -2,19 +2,9 @@
 # Account variables
 ##############################################################################
 
-variable ibmcloud_api_key {
-    description = "The IBM Cloud platform API key needed to deploy IAM enabled resources"
-    type        = string
-}
-
 variable ibm_region {
     description = "IBM Cloud region where all resources will be deployed"
     type        = string
-}
-
-variable generation {
-    description = "Generation of VPC where cluster is deployed"
-    default     = 2
 }
 
 variable resource_group {

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,16 @@ variable cluster_name {
     type        = string
 }
 
+variable k8s_logging_agent_namespace {
+  description = "Namespace on the cluster where logdna agents will be installed"
+  default = "ibm-observe"
+}
+
+variable k8s_monitoring_agent_namespace {
+  description = "Namespace on the cluster where sysdig agents will be installed"
+  default = "ibm-observe"
+}
+
 ##############################################################################
 
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+      version = "~> 1.16.0"
+    }
+  }
+
+}


### PR DESCRIPTION
First I would like to thank you for this module.

However, I needed to use this in a use case where the logging a monitoring instances were in a different resource group than cluster, so I needed to make these changes and I am going up this PR.

I had first submitted PR #1 and PR #2, but after submitting PR 2, I thought better and I believe that just removing the providers setup from this module solves the problem for related use case, since the kubernetes provider is configured in the root module. Besides that, I believe that in most cases it is not so common to have different resource groups for logging and monitoring instances, so this configuration is not necessary. For this reason, I closed the last two PRs and I'm only submitting this one.

In addition, I added `provision_activity_tracker` module variable for README docs.